### PR TITLE
Add allergens to all recipes

### DIFF
--- a/desserts/1-medium/chocolate-cupcakes.md
+++ b/desserts/1-medium/chocolate-cupcakes.md
@@ -1,6 +1,7 @@
 ---
 prep time: 1 hour
 serves: 12 cupcakes
+allergens:  [eggs, milk, nuts, gluten]
 ---
 
 # Chocolate cupcakes

--- a/desserts/1-medium/chocolate-roll.md
+++ b/desserts/1-medium/chocolate-roll.md
@@ -1,5 +1,6 @@
 ---
 serves: an entire family
+allergens:  [milk, gluten]
 ---
 
 # Chocolate roll

--- a/main_courses/0-easy/bulgar_wheat_with_pine_nuts_carrot_and_feta.md
+++ b/main_courses/0-easy/bulgar_wheat_with_pine_nuts_carrot_and_feta.md
@@ -1,3 +1,7 @@
+---
+allergens:  [gluten, nuts, milk]
+---
+
 # Bulgar Wheat with Pine Nuts, Carrot and Feta
 
 ## Ingredients

--- a/main_courses/0-easy/chicken-satay.md
+++ b/main_courses/0-easy/chicken-satay.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [peanuts, soy]
 ---
 
 # Chicken Satay

--- a/main_courses/0-easy/chickpea_spinach_and_egg_curry.md
+++ b/main_courses/0-easy/chickpea_spinach_and_egg_curry.md
@@ -1,3 +1,7 @@
+---
+allergens:  [eggs, mustard]
+---
+
 # Chickpea, spinach and egg curry
 
 ## Ingredients

--- a/main_courses/0-easy/chorizo_linguine.md
+++ b/main_courses/0-easy/chorizo_linguine.md
@@ -1,3 +1,8 @@
+---
+allergens:  [gluten, milk]
+serves: 2 people
+---
+
 # Chorizo Linguine
 
 ## Ingredients

--- a/main_courses/0-easy/instant-pot-spaghetti-meat-sauce.md
+++ b/main_courses/0-easy/instant-pot-spaghetti-meat-sauce.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [gluten]
 ---
 
 # Instant Pot Spaghetti & Meat Sauce

--- a/main_courses/0-easy/pizza-base.md
+++ b/main_courses/0-easy/pizza-base.md
@@ -1,3 +1,7 @@
+---
+allergens:  [gluten]
+---
+
 # Fool-proof Pizza Base
 
 Your friends and family are going to ask you whether Gordon Ramsay assisted.

--- a/main_courses/0-easy/sausage-apple-and-leek-pie.md
+++ b/main_courses/0-easy/sausage-apple-and-leek-pie.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [gluten, eggs, mustard]
 ---
 
 # Sausage, Apple and Leek Pie

--- a/main_courses/0-easy/sausage-casserole.md
+++ b/main_courses/0-easy/sausage-casserole.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [fish]
 ---
 
 # Sausage Casserole

--- a/main_courses/0-easy/slow-cooker-banh-mi.md
+++ b/main_courses/0-easy/slow-cooker-banh-mi.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [soy]
 ---
 
 # Slow Cooker Bánh Mì

--- a/main_courses/0-easy/slow-cooker-honey-sriracha-chicken.md
+++ b/main_courses/0-easy/slow-cooker-honey-sriracha-chicken.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [soy]
 ---
 
 # Slow Cooker Honey Sriracha Chicken

--- a/main_courses/0-easy/spanish-eggs.md
+++ b/main_courses/0-easy/spanish-eggs.md
@@ -1,5 +1,6 @@
 ---
 serves: 3
+allergens:  [eggs]
 ---
 
 # "Spanish" Eggs

--- a/main_courses/0-easy/turkish-eggs.md
+++ b/main_courses/0-easy/turkish-eggs.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [eggs, milk]
 ---
 
 # Turkish Eggs / Shakshuka

--- a/main_courses/1-medium/baked-sausage-with-sweet-potato-and-fennel.md
+++ b/main_courses/1-medium/baked-sausage-with-sweet-potato-and-fennel.md
@@ -2,6 +2,7 @@
 title: "Baked Sausage With Sweet Potato And Fennel"
 tags: [sausage, traybake, sweet-potato]
 serves: 4
+allergens:  [gluten, celery]
 ---
 
 ## Ingredients

--- a/main_courses/1-medium/best-thai-green-curry.md
+++ b/main_courses/1-medium/best-thai-green-curry.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [sulphites]
 ---
 
 # Thai Green Curry

--- a/main_courses/1-medium/courgette-and-mint-soup.md
+++ b/main_courses/1-medium/courgette-and-mint-soup.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [milk]
 ---
 
 # Courgette & Mint soup

--- a/main_courses/1-medium/gorgonzola_risotto_with_sun_dried_tomatoes.md
+++ b/main_courses/1-medium/gorgonzola_risotto_with_sun_dried_tomatoes.md
@@ -1,3 +1,7 @@
+---
+allergens:  [milk]
+---
+
 # Gorgonzola risotto with sun dried tomatoes
 
 ## Ingredients

--- a/main_courses/1-medium/harissa-chicken-traybake.md
+++ b/main_courses/1-medium/harissa-chicken-traybake.md
@@ -1,6 +1,7 @@
 ---
 title: "Harissa Chicken Traybake"
 tags: [chicken, harissa, traybake]
+allergens: [milk]
 ---
 
 ## Ingredients

--- a/main_courses/1-medium/pork-and-pistachio-meatloaf.md
+++ b/main_courses/1-medium/pork-and-pistachio-meatloaf.md
@@ -1,3 +1,7 @@
+---
+allergens:  [gluten, eggs, mustard]
+---
+
 # Pork & Pistachio Meatloaf
 
 ## Ingredients

--- a/main_courses/1-medium/slow_roasted_pork_belly_with_fennel.md
+++ b/main_courses/1-medium/slow_roasted_pork_belly_with_fennel.md
@@ -1,3 +1,7 @@
+---
+allergens:  [mustard]
+---
+
 # Slow-Roasted Pork Belly with Fennel
 
 ## Ingredients

--- a/main_courses/1-medium/steak-pie.md
+++ b/main_courses/1-medium/steak-pie.md
@@ -1,5 +1,6 @@
 ---
 serves: 4
+allergens:  [gluten, eggs]
 ---
 
 # Steak Pie

--- a/main_courses/1-medium/thai-eggs.md
+++ b/main_courses/1-medium/thai-eggs.md
@@ -1,3 +1,7 @@
+---
+allergens:  [soy, sulphites, fish, eggs]
+---
+
 # Thai Eggs
 
 ## Ingredients

--- a/main_courses/2-hard/pierogi.md
+++ b/main_courses/2-hard/pierogi.md
@@ -1,3 +1,7 @@
+---
+allergens:  [gluten, eggs]
+---
+
 # Pierogi
 
 ## Dough 


### PR DESCRIPTION
This PR partially solves #7 by adding allergen tags to all recipes. If someone could review and merge it, that would be great!

## Changes

All recipes have now allergen tags, as per the 14 allergens stated under the food law.
- Where some recipes used allergen-ingredients only for topping/serving, I have omitted the inclusion of that allergen as a tag, as the recipe can be completed without it. 
- Where "flour" was an ingredient, I have included gluten as an allergen.

## Justification

It will make it easier to quickly see that a recipe contains several allergens at a glance. It was long requested since #7.