### PR TITLE
Remove pull request trigger from deployment workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,8 +4,6 @@ name: Build the cookbook
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This PR removes the "pull_request" trigger from the GitHub Action.

I (and probably others who watch this repository) get notified when a Github Action workflow fails. Since the workflow is meant for deployment, it doesn't make sense to run it on a PR.